### PR TITLE
Fixed memory allocation issue,

### DIFF
--- a/Sol/Source/GalaxyDraw/Interfaces/Renderer3D.cpp
+++ b/Sol/Source/GalaxyDraw/Interfaces/Renderer3D.cpp
@@ -171,8 +171,6 @@ namespace GalaxyDraw
 			return;
 		}
 
-		uint32_t maxVerts = s_3DData.MaxMeshes * mesh->Vertices.size();
-		uint32_t maxIndices = s_3DData.MaxMeshes * mesh->Indices.size();
 
 		MeshRenderData meshData;
 		meshData.m_Mesh = mesh;
@@ -189,6 +187,7 @@ namespace GalaxyDraw
 
 		meshData.m_VertexArray->AddVertexBuffer(meshData.m_VertexBuffer);
 
+		uint32_t maxVerts = mesh->Vertices.size();
 		meshData.VertexBufferBase = new Vertex[maxVerts];
 		meshData.InstanceBufferBase = new InstanceData[s_3DData.MaxMeshes];
 


### PR DESCRIPTION
We were allocating memory to accomodate an array of verticies the size of the mesh verts multiplied by the max allowed meshes. This was originally used for storing multiple instances of vertex buffer data for each instance. However now with the changes to how we handle instanced rendering every unique mesh only needs one vertex buffer array the same size as the amount of verticies the mesh consists of. All instances of a mesh share the same vertex buffer array.